### PR TITLE
fix: address n8n review feedback

### DIFF
--- a/credentials/EUrouterApi.credentials.ts
+++ b/credentials/EUrouterApi.credentials.ts
@@ -27,7 +27,7 @@ export class EUrouterApi implements ICredentialType {
 		},
 		{
 			displayName:
-				'⚙️ <b>App Attribution</b> (optional)<br/>By default, every request from this node is attributed to <b>n8n</b> in EUrouter analytics. If you are embedding n8n inside your own product, you can override the attribution below to track usage under your own brand. <a href="https://www.eurouter.ai/docs/concepts/app-attribution" target="_blank">Learn more</a>.',
+				'<b>App Attribution</b> (optional)<br/>By default, every request from this node is attributed to <b>n8n</b> in EUrouter analytics. If you are embedding n8n inside your own product, you can override the attribution below to track usage under your own brand. <a href="https://www.eurouter.ai/docs/concepts/app-attribution" target="_blank">Learn more</a>.',
 			name: 'attributionNotice',
 			type: 'notice',
 			default: '',

--- a/nodes/EUrouterChatModel/EUrouterChatModel.node.ts
+++ b/nodes/EUrouterChatModel/EUrouterChatModel.node.ts
@@ -59,7 +59,7 @@ export class EUrouterChatModel implements INodeType {
 		properties: [
 			{
 				displayName:
-					'🇪🇺 Every request is routed through European infrastructure by default. Use the <b>Provider Routing & Privacy</b> options below to lock down to a specific country, EU-owned providers only, zero data retention, or no training-data collection.',
+					'Every request is routed through European infrastructure by default. Use the <b>Provider Routing & Privacy</b> options below to lock down to a specific country, EU-owned providers only, zero data retention, or no training-data collection.',
 				name: 'eUrouterNotice',
 				type: 'notice',
 				default: '',
@@ -100,12 +100,6 @@ export class EUrouterChatModel implements INodeType {
 								],
 							},
 						},
-					},
-				},
-				routing: {
-					send: {
-						type: 'body',
-						property: 'model',
 					},
 				},
 				default: 'claude-sonnet-4-6',

--- a/nodes/EUrouterEmbeddings/EUrouterEmbeddings.node.ts
+++ b/nodes/EUrouterEmbeddings/EUrouterEmbeddings.node.ts
@@ -57,7 +57,7 @@ export class EUrouterEmbeddings implements INodeType {
 		properties: [
 			{
 				displayName:
-					'🇪🇺 Embeddings often touch entire document corpora, so the <b>Provider Routing & Privacy</b> options below let you pin a country, EU-owned providers only, zero retention, and no training-data collection.',
+					'Embeddings often touch entire document corpora, so the <b>Provider Routing & Privacy</b> options below let you pin a country, EU-owned providers only, zero retention, and no training-data collection.',
 				name: 'eUrouterEmbeddingsNotice',
 				type: 'notice',
 				default: '',
@@ -105,12 +105,6 @@ export class EUrouterEmbeddings implements INodeType {
 								],
 							},
 						},
-					},
-				},
-				routing: {
-					send: {
-						type: 'body',
-						property: 'model',
 					},
 				},
 				default: 'bge-m3',


### PR DESCRIPTION
## Summary
- Remove emojis from notice `displayName` fields in credentials, chat model, and embeddings nodes (not permitted in n8n node UI)
- Remove dead `routing.send` properties on model parameters in both nodes (only evaluated in declarative-style nodes, not programmatic `supplyData()` nodes)

Addresses all 5 items from the n8n package review.